### PR TITLE
Fix issue #145: Responsiveness

### DIFF
--- a/frontend/src/components/User/UserAboutTab.tsx
+++ b/frontend/src/components/User/UserAboutTab.tsx
@@ -59,7 +59,7 @@ const UserAboutTab = () => {
                 <div className="flex justify-start items-start gap-4">
                   <Avatar size="large" name={editName} imageSrc={preview || currentUser.profilePic} />
                 </div>
-                <div className="mx-4">
+                <div className="mx-4 sm:w-fit w-[66%]">
                   <div>
                     <button
                       type="button"


### PR DESCRIPTION
# Pull Request Title

Fixes Responsiveness Bug in Profile > About Section

## Description

This pull request addresses the issue where the text in the upload picture section goes outside the screen width on small screen. 

## Linked Issues

- Fixes #145 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Changes

- Applied `sm:w-fit` and `w-[66%]` classes to ensure the section is responsive and fits within the screen width.

## Screenshots/Recordings

![Screenshot 2024-06-24 100145](https://github.com/aadeshkulkarni/figuringout/assets/130395029/d40a92c2-8dbc-4d24-a525-f223de31d615)
![Screenshot 2024-06-24 100218](https://github.com/aadeshkulkarni/figuringout/assets/130395029/83e18461-198c-4ec0-ad02-80c815e75b8c)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I assure there are no similar/duplicate pull requests regarding the same issue
- [x] My changes follow the project's coding guidelines and best practices
- [x] Code is formatted properly and lint check passes successfully
- [] I have made corresponding changes to the documentation (if applicable)

## Additional Notes

This fix ensure that the section remains responsive across different section sizes.
