### PR TITLE
BugFix | Blog title wrap | Issue #232

### DIFF
--- a/frontend/src/components/Blog/Story.tsx
+++ b/frontend/src/components/Blog/Story.tsx
@@ -39,7 +39,7 @@ const Story = () => {
   return (
     <div className="flex flex-col justify-center items-center p-4 md:px-10">
       <div className="p-4 max-w-[680px]">
-        <div className="text-xl md:text-4xl font-extrabold py-4">{blog?.title}</div>
+        <div className="text-xl md:text-4xl font-extrabold py-4 break-words">{blog?.title}</div>
         <AuthorBox
           name={blog?.author?.name}
           details={blog?.author?.details}
@@ -68,7 +68,7 @@ const ActionBox = () => {
   const { blog, deleteBlog, bookmarkBlog, unbookmarkBlog, likeBlog } = useBlog({
     id: id || '',
   });
-  
+
   const [bookmarked, setBookmarked] = useState(false);
   const user = JSON.parse(localStorage.getItem('user') || '{}') || {};
   const isAuthor = user?.id && user?.id === blog?.author?.id;

--- a/frontend/src/components/BlogCard.tsx
+++ b/frontend/src/components/BlogCard.tsx
@@ -35,7 +35,7 @@ const BlogCard = ({ author, title, content, publishedDate, id, fullWidth, tagsOn
             <span className="text-sm text-slate-500">{formatDateString(publishedDate)}</span>
           </div>
         </div>
-        <div className="order-1 md:order-none text-xl font-bold pt-4">{title}</div>
+        <div className="order-1 md:order-none text-xl font-bold pt-4 break-words">{title}</div>
         <div className="order-2 md:order-none tracking-wide py-4 text-slate-600">
           <ReactQuill value={quillContent} readOnly={true} theme={'bubble'} />
         </div>


### PR DESCRIPTION
# Pull Request Title

Fix: Blog Title wraps correctly before colliding with the blog image(#232)

## Description

This pull request addresses the issue where the blog title was not wrapping correctly and was colliding with the blog image. This fix ensures that the blog title wraps itself before reaching the image, improving the layout and readability of the blog posts. 

Resolves #232 

## Linked Issues

- Fixes #232 

## Type of Change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots/Recordings

Before
![Screenshot 2024-07-04 105050](https://github.com/aadeshkulkarni/figuringout/assets/130395029/0ef8441e-75bd-4146-8b6f-0ed1705d9046)
![Screenshot 2024-07-04 105211](https://github.com/aadeshkulkarni/figuringout/assets/130395029/bb288469-f719-4fc6-87fb-b51ec86a4b43)

After
![Screenshot 2024-07-04 100604](https://github.com/aadeshkulkarni/figuringout/assets/130395029/1de0d763-7a99-4c8b-b387-1e6c02b8eb0c)
![Screenshot 2024-07-04 105339](https://github.com/aadeshkulkarni/figuringout/assets/130395029/2ff15250-b847-4726-8080-2ce191725158)


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I assure there are no similar/duplicate pull requests regarding the same issue
- [x] My changes follow the project's coding guidelines and best practices
- [x] Code is formatted properly and lint check passes successfully
- [ ] I have made corresponding changes to the documentation (if applicable)
