### PR TITLE
Bugfix | Tags with 0 posts

### DIFF
--- a/backend/src/routes/tag.ts
+++ b/backend/src/routes/tag.ts
@@ -23,11 +23,21 @@ tagRouter.get("/", async (c) => {
 			select: {
 				id: true,
 				tagName: true,
+				_count: {
+					select: {
+						tagsOnPost: true,
+					}
+				}
 			},
 			where: {
 				tagsOnPost: {
 					some: {},
 				}
+			},
+			orderBy:{
+				_count: {
+					tagsOnPost: 'desc'
+				},
 			}
 		};
 		const tags = await prisma.tag.findMany(query);

--- a/backend/src/routes/tag.ts
+++ b/backend/src/routes/tag.ts
@@ -24,6 +24,11 @@ tagRouter.get("/", async (c) => {
 				id: true,
 				tagName: true,
 			},
+			where: {
+				tagsOnPost: {
+					some: {},
+				}
+			}
 		};
 		const tags = await prisma.tag.findMany(query);
 		return c.json({


### PR DESCRIPTION
# Pull Request Title

Tags with 0 posts 

## Description

To make sure when fetching the tags from the backed only the tags with at least 1 post is sent and not all.

## Linked Issues

- Fixes #241

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Changes

- On the tag-router  get('/') route I have added a where query which checks for tagsOnPost

## Checklist before requesting a review

-  I have performed a self-review of my code
- I assure there are no similar/duplicate pull requests regarding the same issue
-  My changes follow the project's coding guidelines and best practices
-  Code is formatted properly and lint check passes successfully
-  I have made corresponding changes to the documentation (if applicable)