### PR TITLE
Fixed Issue#247 light input borders

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1529,6 +1529,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
       "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@aadeshk/medium-common": "^1.0.2",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.0",
+    "@react-oauth/google": "^0.12.1",
     "@types/quill": "^2.0.14",
     "animate.css": "^4.1.1",
     "axios": "^1.6.8",
@@ -43,8 +44,7 @@
     "tailwind-merge": "^2.3.0",
     "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss-animate": "^1.0.7",
-    "typewriter-effect": "^2.21.0",
-    "@react-oauth/google": "^0.12.1"
+    "typewriter-effect": "^2.21.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.3.0",

--- a/frontend/src/components/TextField.tsx
+++ b/frontend/src/components/TextField.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent } from 'react';
+import { Input } from './ui/input';
 
 interface TextFieldType {
   id?: string;
@@ -16,14 +17,14 @@ const TextField = ({ id, label, suffix, name = 'txtField', value, type = 'text',
       <label htmlFor={id} className="block mb-2 text-sm font-medium text-main">
         {label}
       </label>
-      <input
+      <Input
         type={type}
         name={name}
-        className="w-full border rounded border-gray-100 resize-none p-3 mb-2 bg-sub"
+        className="w-full border rounded border-gray-500 resize-none p-3 mb-2 bg-sub"
         value={value}
         onChange={onChange}
       />
-      <label className="text-gray-600 text-xs">{suffix}</label>
+      <label className="text-gray-400 text-xs">{suffix}</label>
     </div>
   );
 };

--- a/frontend/src/components/User/UserAboutTab.tsx
+++ b/frontend/src/components/User/UserAboutTab.tsx
@@ -5,6 +5,7 @@ import TextField from '../TextField';
 import Avatar from '../Avatar';
 import { toast } from 'react-toastify';
 import { FF_IMAGE_UPLOADS } from '../../config';
+import { Button } from '../ui/button';
 
 const UserAboutTab = () => {
   const { currentUser, editingDetails, isAuthorizedUser, editUserDetails } = useContext(UserProfileContext);
@@ -61,21 +62,21 @@ const UserAboutTab = () => {
                 </div>
                 <div className="mx-4 sm:w-fit w-[66%]">
                   <div>
-                    <button
+                    <Button
                       type="button"
                       className="text-green-700 py-2 border-none"
                       onClick={() => inputFile?.current?.click()}
                     >
                       Update
-                    </button>
-                    <button
+                    </Button>  &nbsp;&nbsp;
+                    <Button
                       disabled={!editPicture}
                       type="button"
                       onClick={() => setEditPicture(null)}
                       className="text-red-700 px-4 py-2 border-none disabled:opacity-50"
                     >
                       Remove
-                    </button>
+                    </Button>
                     <input
                       type="file"
                       ref={inputFile}
@@ -108,20 +109,20 @@ const UserAboutTab = () => {
             }}
             suffix="Appears on your Profile and next to your stories."
           />
-          <button
+          <Button
             type="submit"
             onClick={handleSubmit}
             className="cursor-pointer focus:outline-none text-white bg-green-700 hover:bg-green-800 focus:ring-4 focus:ring-green-300 font-medium rounded-full text-sm px-5 py-2.5 mt-4"
           >
             {editingDetails ? <Spinner className="w-4 h-4" /> : <div>Save</div>}
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             onClick={() => {}}
             className="ml-4 cursor-pointer focus:outline-none text-green-700 border border-green-700 hover:bg-green-800 hover:text-white focus:ring-4 focus:ring-green-300 font-medium rounded-full text-sm px-5 py-2.5 mt-4"
           >
             {editingDetails ? <Spinner className="w-4 h-4" /> : <div>Cancel</div>}
-          </button>
+          </Button>
         </>
       )}
     </form>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,55 +1,56 @@
-import * as React from 'react';
-import { Slot } from '@radix-ui/react-slot';
-import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from '@/lib/utils';
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        premium: 'bg-emerald-700 text-primary-foreground hover:bg-primary/90',
-        link: 'text-primary underline-offset-4 hover:underline',
-      },
-      rounded: {
-        none: '',
-        small: 'rounded-sm',
-        large: 'rounded-lg',
-        full: 'rounded-full',
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: 'h-8 px-4 py-2',
-        sm: 'h-9 rounded-md px-3',
-        lg: 'h-11 rounded-md px-8',
-        icon: 'h-10 w-10',
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
       },
     },
     defaultVariants: {
-      variant: 'default',
-      size: 'default',
-      rounded: 'none',
+      variant: "default",
+      size: "default",
     },
   }
-);
+)
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
+  asChild?: boolean
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, rounded, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button';
-    return <Comp className={cn(buttonVariants({ variant, size, rounded, className }))} ref={ref} {...props} />;
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
   }
-);
-Button.displayName = 'Button';
+)
+Button.displayName = "Button"
 
-export { Button, buttonVariants };
+export { Button, buttonVariants }

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }


### PR DESCRIPTION
# Pull Request Title

Fix for the issue - 247 Light Input borders

## Description

Summary:
Changed the border-color of the input fields to the color border-gray-500 and the hint text color to text-gray-400 in dark mode.
Installed input and button components from shadcn/ui in ui folder.
Replaced existing inputs, buttons with Shadcn components.

Resolves #247 


