### PR TITLE
Fix for not storing drafts in local storage and auto Saving in 5 sec

### DIFF
--- a/frontend/src/hooks/useAutoSaveDraft.ts
+++ b/frontend/src/hooks/useAutoSaveDraft.ts
@@ -12,14 +12,13 @@ const useAutoSaveDraft = (name: string, getDraft: () => Content) => {
   const userJSON = localStorage.getItem('user') || '{}';
   const user = JSON.parse(userJSON);
 
-  useTimerInterval(15000, autoSaveHandler);
+  useTimerInterval(5000, autoSaveHandler);
 
   async function autoSaveHandler() {
     setIsSaving(true);
     const draft = { ...getDraft() };
     const currentDrafts = readDraftFromLocalStorage();
     currentDrafts[name] = draft;
-    currentDrafts[name] = undefined;
     localStorage.setItem(STORAGE_KEY.WRITE_DRAFT(user.id), JSON.stringify(currentDrafts));
     await new Promise((resolve) => setTimeout(resolve, 500));
     setLastSaved(Date.now());


### PR DESCRIPTION
# Pull Request Title

Fix for not storing drafts in local storage and auto Saving in 5 sec

## Description
Issue reported was the while write an article, the drafts were not being saved in local storage. Also, the interval for saving was set to 15 sec. 

Resolves #226
 
## Linked Issues

- Fixes #226 
- Closes #226

## Type of Change
- Bug fix (non-breaking change which fixes an issue)

## Changes
- remove statement that was assigning undefined to the draft
- change the interval of autosaving from 15 sec to 5 sec


## Screenshots/Recordings


## Checklist before requesting a review

- I have performed a self-review of my code
- I assure there are no similar/duplicate pull requests regarding the same issue
- My changes follow the project's coding guidelines and best practices
- Code is formatted properly and lint check passes successfully
- I have made corresponding changes to the documentation (if applicable)

